### PR TITLE
Get the affine transform directly from the NIfTI header

### DIFF
--- a/fft_simulation/fft_simulation.py
+++ b/fft_simulation/fft_simulation.py
@@ -33,8 +33,9 @@ def load_sus_dist(filepath):
     susceptibility_distribution = image.get_fdata()
     header = image.header
     image_resolution = np.array(header.get_zooms())
+    affine_matrix = image.affine
 
-    return susceptibility_distribution, image_resolution
+    return susceptibility_distribution, image_resolution, affine_matrix
 
 
 def compute_bz(susceptibility_distribution, image_resolution=np.array([1,1,1]), buffer=1):
@@ -84,20 +85,19 @@ def compute_bz(susceptibility_distribution, image_resolution=np.array([1,1,1]), 
 
     return volume_without_buffer
 
-def save_to_nifti(data, image_resolution, output_path):
+def save_to_nifti(data, affine_matrix, output_path):
     """
     Save data to NIfTI format to a specified output path.
 
     Args:
         data (np.array): the data to save
-        img_res (np.array): the spatial resolution of the data
+        affine_matrix (np.array): the affine matrix of the data
         output_path (str): the output path to save the file
 
     Returns:
         None
     """
-    affine = np.diag(np.append(image_resolution,1))
-    nifti_image = nib.Nifti1Image(data, affine)
+    nifti_image = nib.Nifti1Image(data, affine_matrix)
     nib.save(nifti_image, output_path)
 
 
@@ -119,9 +119,9 @@ def compute_fieldmap(input_file, output_file):
         None
     """
     if is_nifti(input_file):
-        sus_dist, img_res = load_sus_dist(input_file)
-        fieldmap = compute_bz(sus_dist, img_res)
-        save_to_nifti(fieldmap, img_res, output_file)
+        susceptibility_distribution, image_resolution, affine_matrix = load_sus_dist(input_file)
+        fieldmap = compute_bz(susceptibility_distribution, image_resolution)
+        save_to_nifti(fieldmap, affine_matrix, output_file)
     else:
         print("The input file must be NIfTI.")
 

--- a/tests/test_fft_simulation.py
+++ b/tests/test_fft_simulation.py
@@ -15,14 +15,15 @@ def test_is_nifti():
     
 def test_load_sus_dist(tmpdir):
     data = np.random.rand(32, 32, 32)
-    affine = np.eye(4)
-    nifti_imagw = nib.Nifti1Image(data, affine)
+    affine_matrix = np.eye(4)
+    nifti_imagw = nib.Nifti1Image(data, affine_matrix)
     filepath = os.path.join(tmpdir, 'output_image.nii')
     nib.save(nifti_imagw, filepath)
-    loaded_data, image_resolution = load_sus_dist(filepath)
+    loaded_data, image_resolution, loaded_affine_matrix = load_sus_dist(filepath)
 
     assert np.array_equal(loaded_data, data), "load_sus_dist failed to retrive the image data correctly"
     assert np.array_equal(image_resolution, [1,1,1]), "load_sus_dist failed to retrive the image resolution correctly"
+    assert np.array_equal(loaded_affine_matrix, affine_matrix), "load_sus_dist failed to retrive the affine matrix correctly"
 
 def test_compute_bz_zero_susceptibility():
     zero_susceptibility = np.zeros((64,64,64))
@@ -39,17 +40,16 @@ def test_compute_bz_uniform_susceptibility():
 
 def test_save_to_nifti(tmpdir):
     data = np.random.rand(32, 32, 32)
-    image_resolution = np.array([1,1,1])
+    affine_matrix = np.eye(4)
     filepath = os.path.join(tmpdir, 'output_image.nii')
-    save_to_nifti(data, image_resolution, filepath)
+    save_to_nifti(data, affine_matrix, filepath)
 
     loaded_nii = nib.load(filepath)
-    header = loaded_nii.header
     loaded_data = loaded_nii.get_fdata()
-    loaded_image_resolution = header.get_zooms()
+    loaded_affine_matrix = loaded_nii.affine
 
     assert np.array_equal(data, loaded_data), "save_to_nifti failed to save the image data correctly"
-    assert np.array_equal(image_resolution, loaded_image_resolution), "save_to_nifti failed to save the image resolution correctly"
+    assert np.array_equal(affine_matrix, loaded_affine_matrix), "save_to_nifti failed to save the affine matrix correctly"
 
 
 


### PR DESCRIPTION
To avoid hard-coding, directly retrieve the affine matrix from the initial susceptibility distribution file. 

Fixes #7 