### PR TITLE
Cp/17 bugfix in compute fieldmap

### DIFF
--- a/functions/compute_fieldmap.py
+++ b/functions/compute_fieldmap.py
@@ -1,7 +1,7 @@
 import numpy as np
 import nibabel as nib
 import click
-from time import time
+from time import perf_counter
 
 def is_nifti(filepath):
     """
@@ -119,7 +119,7 @@ def compute_fieldmap(input_file, output_file):
         None
     """
     if is_nifti(input_file):
-        tic = time()
+        start_time = perf_counter()
         print('Start')
         susceptibility_distribution, image_resolution, affine_matrix = load_sus_dist(input_file)
         print('Susceptibility distribution loaded')
@@ -127,8 +127,8 @@ def compute_fieldmap(input_file, output_file):
         print('Fieldmap simulated')
         save_to_nifti(fieldmap, affine_matrix, output_file)
         print('Saving to NIfTI format')
-        tac = time()
-        print(f'End. Runtime: {tac-tic:.2f} seconds')
+        end_time = perf_counter()
+        print(f'End. Runtime: {end_time-start_time:.2f} seconds')
     else:
         print("The input file must be NIfTI.")
 

--- a/functions/compute_fieldmap.py
+++ b/functions/compute_fieldmap.py
@@ -61,11 +61,10 @@ def compute_bz(susceptibility_distribution, image_resolution=np.array([1,1,1]), 
     # creating the k-space grid with the buffer
     new_dimensions = buffer*np.array(dimensions)
     kmax = 1/(2*image_resolution)
-    interval = 2*kmax/new_dimensions
 
-    [kx, ky, kz] = np.meshgrid(np.arange(-kmax[0], kmax[0], interval[0]),
-                                np.arange(-kmax[1], kmax[1], interval[1]),
-                                np.arange(-kmax[2], kmax[2], interval[2]))
+    [kx, ky, kz] = np.meshgrid(np.linspace(-kmax[0], kmax[0], new_dimensions[0]),
+                                np.linspace(-kmax[1], kmax[1], new_dimensions[1]),
+                                np.linspace(-kmax[2], kmax[2], new_dimensions[2]))
 
     # FFT procedure
     # undetermined at the center of k-space

--- a/functions/compute_fieldmap.py
+++ b/functions/compute_fieldmap.py
@@ -1,6 +1,7 @@
 import numpy as np
 import nibabel as nib
 import click
+from time import time
 
 def is_nifti(filepath):
     """
@@ -118,9 +119,16 @@ def compute_fieldmap(input_file, output_file):
         None
     """
     if is_nifti(input_file):
+        tic = time()
+        print('Start')
         susceptibility_distribution, image_resolution, affine_matrix = load_sus_dist(input_file)
+        print('Susceptibility distribution loaded')
         fieldmap = compute_bz(susceptibility_distribution, image_resolution)
+        print('Fieldmap simulated')
         save_to_nifti(fieldmap, affine_matrix, output_file)
+        print('Saving to NIfTI format')
+        tac = time()
+        print(f'End. Runtime: {tac-tic:.2f} seconds')
     else:
         print("The input file must be NIfTI.")
 

--- a/functions/compute_fieldmap.py
+++ b/functions/compute_fieldmap.py
@@ -65,7 +65,7 @@ def compute_bz(susceptibility_distribution, image_resolution=np.array([1,1,1]), 
 
     [kx, ky, kz] = np.meshgrid(np.linspace(-kmax[0], kmax[0], new_dimensions[0]),
                                 np.linspace(-kmax[1], kmax[1], new_dimensions[1]),
-                                np.linspace(-kmax[2], kmax[2], new_dimensions[2]))
+                                np.linspace(-kmax[2], kmax[2], new_dimensions[2]), indexing='ij')
 
     # FFT procedure
     # undetermined at the center of k-space


### PR DESCRIPTION
There was an error occuring when the susceptibility distribution had different x and y dimensions:

![image](https://github.com/user-attachments/assets/6c46e654-1161-443a-a61d-04ab60681c5f)

When using the np.meshgrip function, the indexing was not specify so the default 'xy' was used. Changed it for 'ij'.

Closes #17 .